### PR TITLE
Implement dog quiz worker

### DIFF
--- a/apps/dog-quiz/package.json
+++ b/apps/dog-quiz/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dog-quiz",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "start": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "types": "wrangler types --include-env=false"
+  },
+  "dependencies": {
+    "@repo/mcp-common": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "0.8.14",
+    "@types/node": "22.14.1",
+    "prettier": "3.5.3",
+    "typescript": "5.5.4",
+    "vitest": "3.0.9",
+    "wrangler": "4.10.0"
+  }
+}

--- a/apps/dog-quiz/src/dog-quiz.app.ts
+++ b/apps/dog-quiz/src/dog-quiz.app.ts
@@ -1,0 +1,64 @@
+export interface Env {
+  DOG_IMAGES: R2Bucket
+}
+
+interface DogInfo {
+  name: string
+  gender: string
+  breed: string
+  age: number
+  imageUrl?: string
+}
+
+const sessions = new Map<string, DogInfo>()
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url)
+    if (url.pathname === '/api/quiz/start' && req.method === 'POST') {
+      const info = (await req.json()) as Partial<DogInfo>
+      if (!info.name || !info.gender || !info.breed || typeof info.age !== 'number') {
+        return jsonResponse({ error: 'Missing dog details' }, 400)
+      }
+      const id = crypto.randomUUID()
+      sessions.set(id, info as DogInfo)
+      return jsonResponse({ id })
+    }
+
+    if (url.pathname === '/api/quiz/image' && req.method === 'POST') {
+      const { id } = Object.fromEntries(url.searchParams)
+      if (!id || !sessions.has(id)) {
+        return jsonResponse({ error: 'Invalid session' }, 400)
+      }
+      const info = sessions.get(id) as DogInfo
+      const formData = await req.formData()
+      const file = formData.get('file') as File | null
+      let imageData: ArrayBuffer
+      let filename: string
+
+      if (file) {
+        imageData = await file.arrayBuffer()
+        filename = `${id}-upload`
+      } else {
+        const text = `Image of ${info.breed} ${info.gender} named ${info.name}`
+        imageData = new TextEncoder().encode(text).buffer
+        filename = `${id}-generated.txt`
+      }
+
+      await env.DOG_IMAGES.put(filename, imageData)
+      const urlBase = 'https://pub-54eaf3ceb23642c1b8e28724cd75f23e.r2.dev/'
+      info.imageUrl = urlBase + filename
+      sessions.set(id, info)
+      return jsonResponse({ imageUrl: info.imageUrl })
+    }
+
+    return new Response('Not found', { status: 404 })
+  },
+}

--- a/apps/dog-quiz/tsconfig.json
+++ b/apps/dog-quiz/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@repo/typescript-config/workers.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "types": ["@types/node"]
+  }
+}

--- a/apps/dog-quiz/wrangler.json
+++ b/apps/dog-quiz/wrangler.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "main": "src/dog-quiz.app.ts",
+  "compatibility_date": "2025-03-10",
+  "compatibility_flags": ["nodejs_compat"],
+  "name": "dog-quiz",
+  "r2_buckets": [
+    {"binding": "DOG_IMAGES", "bucket_name": "dog-images"}
+  ],
+  "vars": {},
+  "dev": {"port": 8787}
+}


### PR DESCRIPTION
## Summary
- add new `dog-quiz` worker app
- implement `/api/quiz/start` and `/api/quiz/image` endpoints
- store uploaded or generated placeholder image to R2 bucket

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6886369aa1d8832e8558a0976df5988b